### PR TITLE
Add some cache operation methods and an atomic buffer clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 examples/
 bin/
 go.work
+.DS_Store

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -1,12 +1,13 @@
 package benchmark
 
 import (
-	"github.com/dgraph-io/ristretto"
-	"github.com/lxzan/memorycache"
-	"github.com/lxzan/memorycache/internal/utils"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/lxzan/memorycache"
+	"github.com/lxzan/memorycache/internal/utils"
 )
 
 const benchcount = 1000000
@@ -48,6 +49,20 @@ func BenchmarkMemoryCache_Get(b *testing.B) {
 		for pb.Next() {
 			index := i.Add(1) % benchcount
 			mc.Get(benchkeys[index])
+		}
+	})
+}
+
+func BenchmarkMemoryCache_GetOrCreate(b *testing.B) {
+	var mc = memorycache.New(
+		memorycache.WithBucketNum(128),
+		memorycache.WithBucketSize(1000, 10000),
+	)
+	var i = atomic.Int64{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			index := i.Add(1) % benchcount
+			mc.GetOrCreate(benchkeys[index], 1, time.Hour)
 		}
 	})
 }

--- a/options.go
+++ b/options.go
@@ -1,7 +1,6 @@
 package memorycache
 
 import (
-	"math"
 	"time"
 
 	"github.com/lxzan/memorycache/internal/utils"
@@ -54,7 +53,7 @@ func WithInterval(min, max time.Duration) Option {
 
 func withInitialize() Option {
 	return func(c *config) {
-		if c.BucketNum <= 0 || c.BucketNum > math.MaxInt8 {
+		if c.BucketNum <= 0 {
 			c.BucketNum = defaultBucketNum
 		}
 		c.BucketNum = utils.ToBinaryNumber(c.BucketNum)

--- a/options.go
+++ b/options.go
@@ -1,8 +1,10 @@
 package memorycache
 
 import (
-	"github.com/lxzan/memorycache/internal/utils"
+	"math"
 	"time"
+
+	"github.com/lxzan/memorycache/internal/utils"
 )
 
 const (
@@ -52,7 +54,7 @@ func WithInterval(min, max time.Duration) Option {
 
 func withInitialize() Option {
 	return func(c *config) {
-		if c.BucketNum <= 0 {
+		if c.BucketNum <= 0 || c.BucketNum > math.MaxInt8 {
 			c.BucketNum = defaultBucketNum
 		}
 		c.BucketNum = utils.ToBinaryNumber(c.BucketNum)


### PR DESCRIPTION
Add some cache operation methods, correct file naming, and improve the test cases of operation methods. Add an atomic buffer clock to avoid time object memory explosion under high pressure.